### PR TITLE
Add fine overrides for feed/speed and remap spindle button to fan toggle

### DIFF
--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -1326,36 +1326,50 @@ draw_main_screen(1);
         }}
         if (macro_lower_pressed){
           if (gpio_get(LOWERBUTTON)){
-            //switch screen to jogmode
-            //screenmode = JOGGING;
-            //send jog character
-            key_character = MACROLOWER;
-            keypad_sendchar (key_character, 1, 1);
-            update_neopixels();
-          }//button is still pressed, Jog A Axis
-          else{
-            //key raised, switch back to alt mode
-            //gpio_put(KPSTR_PIN, false);
-            gpio_put(ONBOARD_LED,1);
-            macro_lower_pressed = 0;
-            sleep_ms(10);
-            update_neopixels();
-        }}
-        if (macro_raise_pressed){
-          if (gpio_get(RAISEBUTTON)){
-            //switch screen to jogmode
-            //screenmode = JOGGING;
-            //send jog character
-            key_character = MACRORAISE;
-            keypad_sendchar (key_character, 1, 1);
-            update_neopixels();
+            if(packet->a_coordinate != 0xFFFFFFFF){
+              //switch screen to jogmode
+              screenmode = JOGGING;
+              //send jog character
+              key_character = MACROLOWER;
+              keypad_sendchar (key_character, 0, 1);
+              update_neopixels();
+            } else {
+              key_character = MACROLOWER;
+              keypad_sendchar (key_character, 1, 1);
+              update_neopixels();
+            }
           }//button is still pressed, Jog A Axis//button is still pressed, Jog A axis
           else{
-            //gpio_put(KPSTR_PIN, false);
-            gpio_put(ONBOARD_LED,1);
-            macro_raise_pressed = 0;
-            sleep_ms(10);
-            update_neopixels();
+              if(packet->a_coordinate != 0xFFFFFFFF)          
+                gpio_put(KPSTR_PIN, false);
+              gpio_put(ONBOARD_LED,1);
+              macro_raise_pressed = 0;
+              sleep_ms(10);
+              update_neopixels();
+              
+        }}  
+        if (macro_raise_pressed){
+          if (gpio_get(RAISEBUTTON)){
+            if(packet->a_coordinate != 0xFFFFFFFF){
+              //switch screen to jogmode
+              screenmode = JOGGING;
+              //send jog character
+              key_character = MACRORAISE;
+              keypad_sendchar (key_character, 0, 1);
+              update_neopixels();
+            } else {
+              key_character = MACRORAISE;
+              keypad_sendchar (key_character, 1, 1);
+              update_neopixels();
+            }
+          }//button is still pressed, Jog A Axis//button is still pressed, Jog A axis
+          else{
+              if(packet->a_coordinate != 0xFFFFFFFF)          
+                gpio_put(KPSTR_PIN, false);
+              gpio_put(ONBOARD_LED,1);
+              macro_raise_pressed = 0;
+              sleep_ms(10);
+              update_neopixels();              
         }}        
         if (spinon_pressed){
           if (gpio_get(SPINDLEBUTTON)){}//button is still pressed, do nothing

--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -1343,7 +1343,7 @@ draw_main_screen(1);
               if(packet->a_coordinate != 0xFFFFFFFF)          
                 gpio_put(KPSTR_PIN, false);
               gpio_put(ONBOARD_LED,1);
-              macro_raise_pressed = 0;
+              macro_lower_pressed = 0;
               sleep_ms(10);
               update_neopixels();
               

--- a/FW/i2c_responder/app_main.cpp
+++ b/FW/i2c_responder/app_main.cpp
@@ -100,10 +100,14 @@ uint8_t key_character = '\0';
 
 uint8_t feed_up_pressed = 0;
 uint8_t feed_down_pressed = 0;
+uint8_t feed_up_fine_pressed = 0;
+uint8_t feed_down_fine_pressed = 0;
 uint8_t feed_reset_pressed = 0;
 
 uint8_t spin_up_pressed = 0;
 uint8_t spin_down_pressed = 0;
+uint8_t spin_up_fine_pressed = 0;
+uint8_t spin_down_fine_pressed = 0;
 uint8_t spin_reset_pressed = 0;
 
 uint8_t jog_mod_pressed = 0;
@@ -958,15 +962,23 @@ draw_main_screen(1);
           //gpio_put(KPSTR_PIN, false);    
         //misc commands.  These activate on lift
         } else if (gpio_get(SPINOVER_UP)){  
-          spin_up_pressed = 1;            
-        } else if (gpio_get(SPINOVER_DOWN)){  
-          spin_down_pressed = 1;
+          if(!jog_toggle_pressed){    
+            spin_up_pressed = 1;
+          }            
+        } else if (gpio_get(SPINOVER_DOWN)){
+          if(!jog_toggle_pressed){    
+            spin_down_pressed = 1;
+          }
         } else if (gpio_get(SPINOVER_RESET)){  
           spin_reset_pressed = 1; 
-        } else if (gpio_get(FEEDOVER_UP)){ 
-          feed_up_pressed = 1;    
-        } else if (gpio_get(FEEDOVER_DOWN)){ 
-          feed_down_pressed = 1;            
+        } else if (gpio_get(FEEDOVER_UP)){
+          if(!jog_toggle_pressed){    
+            feed_up_pressed = 1;
+          }    
+        } else if (gpio_get(FEEDOVER_DOWN)){
+          if(!jog_toggle_pressed){     
+            feed_down_pressed = 1;
+          }            
         } else if (gpio_get(FEEDOVER_RESET)){  
           feed_reset_pressed = 1;              
         } else if (gpio_get(HOMEBUTTON)){  
@@ -1141,7 +1153,19 @@ draw_main_screen(1);
             }
             if (gpio_get(HALTBUTTON)){
               halt_pressed = 1;              
-            }                                                                                                                                       
+            }
+            if (gpio_get(SPINOVER_UP)){  
+              spin_up_fine_pressed = 1;            
+            }
+            if (gpio_get(SPINOVER_DOWN)){  
+              spin_down_fine_pressed = 1;
+            }
+            if (gpio_get(FEEDOVER_UP)){ 
+              feed_up_fine_pressed = 1;    
+            }
+            if (gpio_get(FEEDOVER_DOWN)){ 
+              feed_down_fine_pressed = 1;            
+            }                                                                                                                    
           }//close jog toggle pressed.
         }//close jog button pressed statement
 //Single functions ***********************************************************************
@@ -1241,7 +1265,11 @@ draw_main_screen(1);
           if (gpio_get(SPINDLEBUTTON)){}//button is still pressed, do nothing
           else{
             if(!jog_toggle_pressed){
-            key_character = CMD_OVERRIDE_SPINDLE_STOP;
+              if(packet->machine_state.mode == 1){ // SAFETY FOR LASERS TO NOT ENABLE LASER FROM JOG2K
+                key_character = CMD_OVERRIDE_FAN0_TOGGLE;
+              }else{
+                key_character = CMD_OVERRIDE_SPINDLE_STOP;
+              }
             keypad_sendchar (key_character, 1, 1);
             gpio_put(ONBOARD_LED,1);
             }
@@ -1411,6 +1439,46 @@ draw_main_screen(1);
             keypad_sendchar (key_character, 1, 1);
             gpio_put(ONBOARD_LED,1);
             unlock_pressed = 0;
+            sleep_ms(10);
+            update_neopixels();
+        }}
+        if (feed_down_fine_pressed) {
+          if (gpio_get(FEEDOVER_DOWN)){}//button is still pressed, do nothing
+          else{
+            key_character = CMD_OVERRIDE_FEED_FINE_MINUS;
+            keypad_sendchar (key_character, 1, 1);
+            gpio_put(ONBOARD_LED,1);
+            feed_down_fine_pressed = 0;
+            sleep_ms(10);
+            update_neopixels();                       
+         }}
+        if (feed_up_fine_pressed) {
+          if (gpio_get(FEEDOVER_UP)){}//button is still pressed, do nothing
+          else{
+            key_character = CMD_OVERRIDE_FEED_FINE_PLUS;
+            keypad_sendchar (key_character, 1, 1);
+            gpio_put(ONBOARD_LED,1);
+            feed_up_fine_pressed = 0;
+            sleep_ms(10);
+            update_neopixels();                
+        }}
+        if (spin_down_fine_pressed) {
+          if (gpio_get(SPINOVER_DOWN)){}//button is still pressed, do nothing
+          else{
+            key_character = CMD_OVERRIDE_SPINDLE_FINE_MINUS;
+            keypad_sendchar (key_character, 1, 1);
+            gpio_put(ONBOARD_LED,1);
+            spin_down_fine_pressed = 0;
+            sleep_ms(10);
+            update_neopixels();           
+        }}
+        if (spin_up_fine_pressed) {
+          if (gpio_get(SPINOVER_UP)){}//button is still pressed, do nothing
+          else{
+            key_character = CMD_OVERRIDE_SPINDLE_FINE_PLUS;
+            keypad_sendchar (key_character, 1, 1);
+            gpio_put(ONBOARD_LED,1);
+            spin_up_fine_pressed = 0;
             sleep_ms(10);
             update_neopixels();
         }}  

--- a/FW/i2c_responder/i2c_jogger.h
+++ b/FW/i2c_responder/i2c_jogger.h
@@ -2,7 +2,7 @@
 #define __I2C_JOGGER_H__
 
 #define PLUGIN_VERSION "PLUGIN: KEYPAD v1.4"
-#define JOG2K_VERSION  "FW: v1.0.5"
+#define JOG2K_VERSION  "FW: v1.0.6"
 
 // Which pin on the Arduino is connected to the NeoPixels?
 #define PIN        22 // On Trinket or Gemma, suggest changing this to 1

--- a/FW/i2c_responder/i2c_jogger.h
+++ b/FW/i2c_responder/i2c_jogger.h
@@ -2,7 +2,7 @@
 #define __I2C_JOGGER_H__
 
 #define PLUGIN_VERSION "PLUGIN: KEYPAD v1.4"
-#define JOG2K_VERSION  "FW: v1.0.4"
+#define JOG2K_VERSION  "FW: v1.0.5"
 
 // Which pin on the Arduino is connected to the NeoPixels?
 #define PIN        22 // On Trinket or Gemma, suggest changing this to 1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Expatria Technologies jog controller for GRBLHAL2000 and Flexi-HAL boards
 
-This jog controller was developed for the GRLBHAL20000 and Flexi-HAL boards.  It is designed to be relatively inexpensive and simple to assemble.  It needs minimal manual wiring and leverages 3d printable parts for assembly.  The system consists of a small interface module that is installed on the Real-Time/I2C headers on the Flexi-HAL, plus a simple lighted button keypad that uses a Raspberry Pi Pico to send character commands to GRBLHAL and receive status information.  This pendant relies on the modified I2C Keypad plugin that was extended by Expatria Technologies:
+This jog controller was developed for the GRLBHAL20000 and Flexi-HAL boards.  It is designed to be relatively inexpensive and simple to assemble.  It needs minimal manual wiring and leverages 3d printable parts for assembly.  The system consists of a small interface module that is installed on the Real-Time/I2C headers on the Flexi-HAL, plus a simple lighted button keypad that uses an RP2040 microcontroller to send character commands to GRBLHAL and receive status information.  This pendant relies on the modified I2C Keypad plugin that was extended by Expatria Technologies:
 
 https://github.com/Expatria-Technologies/Plugin_I2C_keypad
 


### PR DESCRIPTION
Addition of two features useful for laser operations (and hopefully others):

(1) Add fine overrides as alternate function for override buttons
(2) Remap spindle button to fan toggle command

With regards to the second point, for safety it is generally desirable not to have the laser state toggled on or off via the pendant. I would propose using this button to toggle the fan since it allows for lasers equipped with a LED pilot/guide to connect the trigger for the LED to an aux input and toggle via fan commands. Just a suggestion though and understand if this is not function is not universal enough to warrant merging.